### PR TITLE
[Update]ゲームの表示の中央揃え [issue #11]

### DIFF
--- a/static/css/top.css
+++ b/static/css/top.css
@@ -52,6 +52,7 @@ img {
 
 .photo-container {
   display: flex; /* Flexboxを使用して要素を横に配置 */
+  justify-content: center;
   align-items: center; /* 垂直方向の中央揃え */
   margin-bottom: 20px; /* セクション間の余白を設定 */
 }


### PR DESCRIPTION
- top.css
	- .photo-container {} justify-content: center; を追加

<img width="549" alt="スクリーンショット 2023-09-05 114619" src="https://github.com/IshikawaMasato/visiontraining_2023/assets/101164630/dc283240-1905-411c-a876-9f01cab0211d">
