### PR TITLE
[Update]ゲームタイトル画面の配置変更＆css変更 [issue #14]

### DIFF
--- a/static/css/ref_game.css
+++ b/static/css/ref_game.css
@@ -1,6 +1,21 @@
 @charset "utf-8";
-.open {
-	cursor:pointer;
+.game {
+	font-size: 70px;
+	text-align: center;
+}
+.start {
+	display: flex;
+    flex-direction: column;
+	align-items: center;
+    justify-content: center;
+}
+.return button, .start button {
+	font-size: 30px;
+	width: 290px;
+}
+.pop-up-menu {
+	font-size: 30px;
+	text-align: center;
 }
 #pop-up1, #pop-up2 {
 	display: none;

--- a/templates/game/ref_game/ref_game.html
+++ b/templates/game/ref_game/ref_game.html
@@ -41,15 +41,17 @@
         </script>
     </header>
 
-    <div>
+    <div class="return">
         <button>トップページに戻る</button>
     </div>
-    <h1>反射神経ゲーム</h1>
-    <div>
+    <h1 class="game">反射神経ゲーム</h1>
+    <div class="start">
         <button>ゲームスタート</button>
     </div>
 
-    <label class="open" for="pop-up1">遊び方</label>
+    <div class="pop-up-menu">
+        <label class="open" for="pop-up1">遊び方</label>
+    </div>
     <input type="checkbox" id="pop-up1">
     <div class="overlay">
         <div class="window1">
@@ -62,8 +64,9 @@
             <p>レベルは１０まであります。ゴール目指して頑張りましょう！</p>
         </div>
     </div>
-    <br>
-    <label class="open" for="pop-up2">ランキング</label>
+    <div class="pop-up-menu">
+        <label class="open" for="pop-up2">ランキング</label>
+    </div>
     <input type="checkbox" id="pop-up2">
     <div class="overlay">
         <div class="window2">
@@ -123,6 +126,7 @@
                     </tr>
                 </table>
             </div>
+        </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
- ref_game.html
	- 新しいクラスを指定
- ref_game.css
	- ゲームタイトル・スタートボタン・遊び方・ランキングを中央揃え
	- フォントサイズの変更
	- ※「トップページに戻る」ボタンはそのままの位置
	- ※labelのフォントサイズは変更したが、中の説明・ランキング一覧のフォントサイズは変更なし