### PR TITLE
[Update]反射神経ゲームの結合処理 [issue #64]

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request, redirect, url_for, session
 import db,string,random
 from user import user_bp
 from dva_game import dva_game_bp
+from ref_game import ref_game_bp
 from vision_register import vision_bp
 from datetime import time
 
@@ -10,6 +11,7 @@ app.secret_key = ''.join(random.choices(string.ascii_letters, k=256))
 
 app.register_blueprint(user_bp)
 app.register_blueprint(dva_game_bp)
+app.register_blueprint(ref_game_bp)
 app.register_blueprint(vision_bp)
 # app.permanent_session_lifetime = timedelta(minutes=3)
 

--- a/ref_game.py
+++ b/ref_game.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, render_template, redirect, request, url_for, session
+import db,random,string
+
+ref_game_bp = Blueprint('ref_game', __name__, url_prefix='/game/ref_game')
+
+@ref_game_bp.route('/ref_game')
+def ref_game():
+    return render_template('game/ref_game/ref_game.html')

--- a/templates/content.html
+++ b/templates/content.html
@@ -68,7 +68,7 @@
             5回押したらレベルアップ！<br>
             時間内にすべてのジョビジョビくんを押しましょう！</p>
             <div class="button005">
-              <a href="#">プレイする</a>
+              <a href="{{ url_for('ref_game.ref_game')}}">プレイする</a>
             </div>
         </div>
       </div>

--- a/templates/top_header.html
+++ b/templates/top_header.html
@@ -3,7 +3,7 @@
 
     <nav class="header-nav">
         <ul class="header-list">
-            <li class="header-item"><a href="ref_game.html">反射神経ゲーム</a></li>
+            <li class="header-item"><a href="{{ url_for('ref_game.ref_game')}}">反射神経ゲーム</a></li>
             <li class="header-item"><a href="{{ url_for('dva_game.dva_game') }}">動体視力ゲーム</a></li>
 
         </ul>

--- a/templates/user/user_header.html
+++ b/templates/user/user_header.html
@@ -3,7 +3,7 @@
 
   <nav class="header-nav">
       <ul class="header-list">
-        <li class="header-item"><a href="ref_game.html">反射神経ゲーム</a></li>
+        <li class="header-item"><a href="{{ url_for('ref_game.ref_game')}}">反射神経ゲーム</a></li>
         <li class="header-item"><a href="{{ url_for('dva_game.dva_game')}}">動体視力ゲーム</a></li>
         <li class="header-item"><a href="{{ url_for('vision_register.vision_changes') }}">目標設定</a></li> 
       </ul>

--- a/templates/visiontraining_video.html
+++ b/templates/visiontraining_video.html
@@ -64,7 +64,7 @@
           5回押したらレベルアップ！<br>
           時間内にすべてのジョビジョビくんを押しましょう！</p>
           <div class="button005">
-            <a href="#">プレイする</a>
+            <a href="{{ url_for('ref_game.ref_game') }}">プレイする</a>
           </div>
       </div>
 </div>


### PR DESCRIPTION
- 各htmlファイル
	- aタグのhrefを {{ url_for('ref_game.ref_game')}} に変更
- app.py
	- ref_game_bpをインポート
	- app.register_blueprint(ref_game_bp)を追加
- ref_game.py作成
	- dva_game.pyを参考に作成した

※この処理で、トップページ・利用者ページの「反射神経ゲーム」「プレイする」から、反射神経ゲームの画面に遷移することが確認出来た。