### PR TITLE
[Fix]登録確認画面の画面遷移＆ボタン修正 [issue #82]

### DIFF
--- a/templates/user/account_confirm.html
+++ b/templates/user/account_confirm.html
@@ -78,11 +78,10 @@
         </table>
 
         <tr>
-            <input type="submit" class="button" placeholder="登録">
+            <input type="submit" class="button" value="登録">
         </tr>
-        <button href="{{ url_for('user.register_form')}}">戻る</button>
-
     </form>
+    <a href="{{ url_for('user.register_form')}}"><button>戻る</button></a>
 </div>
 {% include "footer.html"%}
     </body>


### PR DESCRIPTION
- account_confirm.html
	- formの下のinputタグ placeholder→valueに変更
	- ※valueにしないと、表示される文字は「送信」になる
	- 戻るボタン aタグで囲み、aタグにhrefでリンクを指定＆formタグの外に置く
	- ※formタグの中だと、登録結果画面に遷移する